### PR TITLE
Removed unnecessary requirement & added Cython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 absl-py==0.6.1
 astor==0.7.1
 Click==7.0
-Cython==0.29.2
+Cython==0.29.14
 gast==0.2.1
 grpcio==1.17.1
 h5py==2.9.0
@@ -10,7 +10,6 @@ Keras-Preprocessing==1.0.5
 Markdown==3.0.1
 numpy==1.15.4
 pandas==0.23.4
-pkg-resources==0.0.0
 protobuf==3.6.1
 python-dateutil==2.7.5
 pytz==2018.7


### PR DESCRIPTION
pkg-resources==0.0.0 breaks installing from requirements as the package is never found. In addition the current build of Cython does not work with word2vec, Cython 0.29.14 does.